### PR TITLE
Rename package from samoa template to ergo

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 repository:
-  name: samoa
-  description: Template repository for zoobz-io Go packages
-  homepage: https://samoa.zoobz.io
+  name: ergo
+  description: Go library for the zoobz-io ecosystem
+  homepage: https://ergo.zoobz.io
   has_wiki: true
   has_downloads: true
   default_branch: main
@@ -13,8 +13,7 @@ repository:
     - go
     - golang
     - zoobzio
-    - template
-    - boilerplate
+    - library
 
 labels:
   - name: "phase:plan"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,5 +69,5 @@ jobs:
     - name: Verify module is fetchable
       run: |
         sleep 60  # Wait for proxy to update
-        go install github.com/zoobz-io/samoa@${{ github.ref_name }}
+        go install github.com/zoobz-io/ergo@${{ github.ref_name }}
       continue-on-error: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,5 @@
 version: 2
-project_name: samoa
+project_name: ergo
 
 builds:
   - skip: true  # Library packages don't build binaries
@@ -34,7 +34,7 @@ changelog:
 release:
   github:
     owner: zoobz-io
-    name: samoa
+    name: ergo
   draft: false
   prerelease: auto
   mode: append

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to samoa
+# Contributing to ergo
 
-Thank you for considering contributing to samoa.
+Thank you for considering contributing to ergo.
 
 ## Development Setup
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .DEFAULT_GOAL := help
 
 help: ## Display available commands
-	@echo "samoa Development Commands"
+	@echo "ergo Development Commands"
 	@echo "=============================="
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 

--- a/README.md
+++ b/README.md
@@ -1,98 +1,31 @@
-# samoa
+# ergo
 
-[![CI Status](https://github.com/zoobz-io/samoa/workflows/CI/badge.svg)](https://github.com/zoobz-io/samoa/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/zoobz-io/samoa/graph/badge.svg?branch=main)](https://codecov.io/gh/zoobz-io/samoa)
-[![Go Report Card](https://goreportcard.com/badge/github.com/zoobz-io/samoa)](https://goreportcard.com/report/github.com/zoobz-io/samoa)
-[![CodeQL](https://github.com/zoobz-io/samoa/workflows/CodeQL/badge.svg)](https://github.com/zoobz-io/samoa/security/code-scanning)
-[![Go Reference](https://pkg.go.dev/badge/github.com/zoobz-io/samoa.svg)](https://pkg.go.dev/github.com/zoobz-io/samoa)
-[![License](https://img.shields.io/github/license/zoobz-io/samoa)](LICENSE)
-[![Go Version](https://img.shields.io/github/go-mod/go-version/zoobz-io/samoa)](go.mod)
-[![Release](https://img.shields.io/github/v/release/zoobz-io/samoa)](https://github.com/zoobz-io/samoa/releases)
-
-Template repository for standing up Go library infrastructure matching the zoobz-io ecosystem. Clone it, rename it, start building.
-
-## What's Included
-
-```
-your-new-package/
-├── go.mod                    # Go 1.24+ with toolchain
-├── Makefile                  # test, lint, coverage, ci targets
-├── .golangci.yml             # v2 config with security linters
-├── .codecov.yml              # 70% project / 80% patch targets
-├── .goreleaser.yml           # Library release automation
-├── .github/workflows/
-│   ├── ci.yml                # Test matrix, lint, security, benchmarks
-│   ├── coverage.yml          # Codecov integration
-│   ├── release.yml           # Tag-triggered releases
-│   └── codeql.yml            # Security analysis
-├── testing/
-│   ├── helpers.go            # Reusable test utilities
-│   ├── integration/          # Integration test structure
-│   └── benchmarks/           # Benchmark structure
-├── LICENSE                   # MIT
-├── CONTRIBUTING.md           # Development workflow
-└── SECURITY.md               # Vulnerability reporting
-```
+[![CI Status](https://github.com/zoobz-io/ergo/workflows/CI/badge.svg)](https://github.com/zoobz-io/ergo/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/zoobz-io/ergo/graph/badge.svg?branch=main)](https://codecov.io/gh/zoobz-io/ergo)
+[![Go Report Card](https://goreportcard.com/badge/github.com/zoobz-io/ergo)](https://goreportcard.com/report/github.com/zoobz-io/ergo)
+[![CodeQL](https://github.com/zoobz-io/ergo/workflows/CodeQL/badge.svg)](https://github.com/zoobz-io/ergo/security/code-scanning)
+[![Go Reference](https://pkg.go.dev/badge/github.com/zoobz-io/ergo.svg)](https://pkg.go.dev/github.com/zoobz-io/ergo)
+[![License](https://img.shields.io/github/license/zoobz-io/ergo)](LICENSE)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/zoobz-io/ergo)](go.mod)
+[![Release](https://img.shields.io/github/v/release/zoobz-io/ergo)](https://github.com/zoobz-io/ergo/releases)
 
 ## Install
 
-This is a GitHub template repository. Click **Use this template** on GitHub, or:
-
 ```bash
-gh repo create your-package --template zoobz-io/samoa --clone
-cd your-package
+go get github.com/zoobz-io/ergo
 ```
 
-Then update `go.mod`, `Makefile`, and `.goreleaser.yml` with your package name.
-
-## Quick Start
-
-After creating your repository from the template:
+## Development
 
 ```bash
-# Update module path
-sed -i 's/samoa/your-package/g' go.mod Makefile .goreleaser.yml
-
-# Install development tools
-make install-tools
-
-# Verify everything works
-make check
-
-# Start building
+make install-tools  # Install dev tools
+make check          # Lint, test, security scan
+make help           # All available commands
 ```
-
-## Capabilities
-
-| Feature | Description | Configuration |
-|---------|-------------|---------------|
-| Multi-version testing | Go 1.24 and 1.25 matrix | `.github/workflows/ci.yml` |
-| Linting | golangci-lint v2 with security focus | `.golangci.yml` |
-| Coverage tracking | Codecov with PR comments | `.codecov.yml` |
-| Release automation | GoReleaser for library packages | `.goreleaser.yml` |
-| Security scanning | gosec + CodeQL | `.github/workflows/codeql.yml` |
-| Benchmarks | Structured benchmark directory | `testing/benchmarks/` |
-
-## Why Samoa?
-
-- **Immediate CI**: Push and your workflows run—no setup required
-- **Consistent tooling**: Every zoobz-io package uses the same linter config, coverage targets, and release process
-- **Security by default**: gosec, CodeQL, and security-focused linters enabled from day one
-- **Test infrastructure ready**: Helpers, integration tests, and benchmarks structured and waiting
-
-## The Zoobz-io Ecosystem
-
-All zoobz-io Go libraries use samoa as their foundation. When standards evolve, updates propagate from here.
-
-## Documentation
-
-- **Learn**: Review the configuration files directly—they're documented inline
-- **Guides**: See `CONTRIBUTING.md` for development workflow
-- **Reference**: Run `make help` for available commands
 
 ## Contributing
 
-Development workflow and conventions are documented in [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in samoa, please report it responsibly.
+If you discover a security vulnerability in ergo, please report it responsibly.
 
 **Do not open a public issue.**
 

--- a/api.go
+++ b/api.go
@@ -1,16 +1,2 @@
-// Package samoa provides template configurations for zoobz-io packages.
-//
-// This repository serves as the canonical template for all zoobz-io Go libraries,
-// containing standardized configurations for:
-//
-//   - Go module setup (go.mod)
-//   - Linting (.golangci.yml)
-//   - Coverage (.codecov.yml)
-//   - Release automation (.goreleaser.yml)
-//   - CI/CD workflows (.github/workflows/)
-//   - Testing infrastructure (testing/)
-//   - Repository files (LICENSE, CONTRIBUTING.md, SECURITY.md)
-//
-// To create a new zoobz-io package, use this repository as a GitHub template
-// and update package-specific values.
-package samoa
+// Package ergo provides the public API for the ergo library.
+package ergo

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zoobz-io/samoa
+module github.com/zoobz-io/ergo
 
 go 1.24
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,6 +1,6 @@
 # Testing Infrastructure
 
-This directory contains testing utilities and infrastructure for samoa.
+This directory contains testing utilities and infrastructure for ergo.
 
 ## Structure
 
@@ -44,7 +44,7 @@ make test-bench
 Import the testing package:
 
 ```go
-import "github.com/zoobz-io/samoa/testing"
+import "github.com/zoobz-io/ergo/testing"
 ```
 
 ### Coverage Targets

--- a/testing/benchmarks/README.md
+++ b/testing/benchmarks/README.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-This directory contains performance benchmarks for samoa.
+This directory contains performance benchmarks for ergo.
 
 ## Running
 

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -1,6 +1,6 @@
 //go:build testing
 
-// Package testing provides test helpers for samoa.
+// Package testing provides test helpers for ergo.
 package testing
 
 import "testing"

--- a/testing/integration/README.md
+++ b/testing/integration/README.md
@@ -1,6 +1,6 @@
 # Integration Tests
 
-This directory contains integration tests that verify samoa works correctly with external dependencies.
+This directory contains integration tests that verify ergo works correctly with external dependencies.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- Replaces all `samoa` references across 13 files with `ergo` — module path, package declaration, badges, workflow paths, repo settings, and documentation
- Rewrites README as a package skeleton (template docs removed)
- Updates `.github/settings.yml` topics: dropped `template`/`boilerplate`, added `library`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Zero remaining `samoa` references (`grep -r samoa` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)